### PR TITLE
sticky-bit.t test operates on temporary directory now

### DIFF
--- a/t/sticky-bit.t
+++ b/t/sticky-bit.t
@@ -7,6 +7,7 @@ use File::chmod qw( chmod getmod );
 $File::chmod::UMASK = 0;
 
 plan skip_all => "Windows perms work differently" if $OSNAME eq 'MSWin32';
+plan skip_all => "old File::Temp without newdir" if !File::Temp->can('newdir');
 
 my $tmp = File::Temp->newdir;
 my $fn  = $tmp->dirname;


### PR DESCRIPTION
On some systems (e.g. FreeBSD, probably all *BSD systems) setting the
sticky bit on plain files is not allowed. Only directories may get the
sticky bit here:

```
$ touch file
$ chmod +t file
chmod: file: Inappropriate file type or format
```

Fix sticky-bit.t test to use a temporary directory, not a temporary
file.

Overview of test failures may be seen here: http://217.199.168.174/cgi-bin/cpantestersmatrix.pl?dist=File-chmod

Regards, Slaven
