### PR TITLE
Include repo url in deprecation notice

### DIFF
--- a/lib/File/chmod.pm
+++ b/lib/File/chmod.pm
@@ -64,7 +64,8 @@ warnings::warnif 'deprecated', '$UMASK being true is deprecated'
   . ' is being made because this not the behavior of the unix command'
   . ' `chmod`. This warning can be disabled by putting explicitly'
   . ' setting $File::chmod::UMASK to false (0) to act like system chmod,'
-  . ' or any non 2 true value see Github issue #5 '
+  . ' or any non 2 true value see Github issue #5'
+  . ' at https://github.com/xenoterracide/File-chmod'
   if $UMASK == 2;
 
   my @return = getsymchmod($mode,@_);


### PR DESCRIPTION
Since the issue number is mentioned, I think it makes sense to include the project/repo GitHub url too.

---

For whatever reason, `Dist::Zilla` seems to be failing to install with Perls 5.10 and 5.12 ... and that's why the tests appear to be failing.